### PR TITLE
Force favicons package to use sharp v0.23.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "peerDependencies": {
     "gatsby": ">=2.0.0",
     "react": "^16"
+  },
+  "resolutions": {
+	  "favicons-webpack-plugin/favicons/sharp": "0.23.1"
   }
 }


### PR DESCRIPTION
This is needed for last versions of gatsby's packages